### PR TITLE
fix: #27 terraform apply 시 ecs template 문법 오류로 인해 생성 실패하는 부분 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,7 +133,10 @@ dist
 # 컴파일된 파일 
 *.tfstate 
 *.tfstate.backup 
-*.tfvars
+# *.tfvars
+terraform-dev.tfvars
+terraform-stage.tfvars
+terraform-prod.tfvars
 .terraform.tfstate.lock.info
 .apikey.txt
 

--- a/env/dev/.terraform.lock.hcl
+++ b/env/dev/.terraform.lock.hcl
@@ -5,7 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.67.0"
   constraints = "~> 4.0"
   hashes = [
-    "h1:LfOuBkdYCzQhtiRvVIxdP/KGJODa3cRsKjn8xKCTbVY=",
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
     "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
     "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
     "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.3"
   constraints = "~> 3.0"
   hashes = [
-    "h1:+UItZOLue/moJfnI3tqZBQbXUYR4ZnqPYfJDJPgLZy0=",
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
     "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
@@ -47,16 +47,6 @@ provider "registry.terraform.io/hashicorp/random" {
 provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [
-    "h1:LN84cu+BZpVRvYlCzrbPfCRDaIelSyEx/W9Iwwgbnn4=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+    "h1:oOhh0A/w5AQ6D+z5rYHPRujUf3ORazKOpQgRpGP+9yU=",
   ]
 }

--- a/env/dev/terraform.tfvars
+++ b/env/dev/terraform.tfvars
@@ -1,0 +1,275 @@
+# export TF_VAR_ecs_container_image_version="1.0.0"
+# pluralith graph
+
+####################
+# 프로젝트 기본 설정
+####################
+project_name = "terraform-ecs"
+aws_region   = "ap-northeast-2"
+availability_zones = [
+  "ap-northeast-2a",
+  "ap-northeast-2b"
+]
+aws_account = "8xxxxxxxxxxx" # IAM USER: terraform-admin
+env         = "stg"
+
+####################
+# 네트워크 설정
+####################
+# IP 대역
+# 10.0.0.0 - 10.255.255.255		-> 		16,777,216
+# 172.16.0.0 - 172.31.255.255		-> 		1,048,576
+# 192.168.0.0 - 192.168.255.255	->		65,536
+# VPC ID(외부 data 변수를 통해 받음, 초기에는 빈값으로 셋팅)
+vpc_id = ""
+
+# VPC CIDR 대역 지정 - VPC CIDR는 개발환경에 적합한 크기로 설정
+vpc_cidr = "172.22.0.0/16"
+
+# 각 가용영역마다 하나의 public/private 서브넷 -> 가용 영역은 현재 2개
+# 퍼블릭 서브넷 지정 -> 서브넷 당 256개 IP 사용 가능(5개는 빼야함)
+# /24 -> 앞의 3개의 IP가 네트워크 주소, 나머지 8비트가 호스트 비트
+public_subnets_cidr = [
+  "172.22.10.0/24",
+  "172.22.11.0/24"
+]
+
+# 프라이빗 서브넷 지정
+private_subnets_cidr = [
+  "172.22.20.0/24",
+  "172.22.21.0/24"
+]
+
+# 퍼블릭 서브넷 ID 지정
+# public_subnet_ids = [
+#   "subnet-xxxxxxxx",
+#   "subnet-xxxxxxxx"
+# ]
+
+# 프라이빗 서브넷 ID 지정
+# private_subnet_ids = [
+#   "subnet-xxxxxxxx",
+#   "subnet-xxxxxxxx"
+# ]
+
+# DNS Hostname 사용 옵션, 기본 false(VPC 내 리소스가 AWS DNS 주소 사용 가능)
+# DNS 기능 자체를 켤지 말지 정하는 옵션, 키는 경우 VPC에서 DNS 기능 사용 가능
+# 활성화 : DNS -> IP / IP -> DNS
+# 비활성화 : IP로만 통신 가능
+enable_dns_support = true
+
+# DNS 이름을 만들지 말지 정하는 옵션, 이것도 켜야 실제 VPC 내의 리소스들이 DNS로 통신이 가능할 듯
+enable_dns_hostnames = true
+
+####################
+# 로드밸런서 설정
+####################
+# ALB 생성
+# -> ALB의 KEY 이름과, Target Group 변수의 KEY 이름을 일치시켜야 함
+alb = {
+  "terraform-ecs-alb" = {
+    alb_name                             = "terraform-ecs-alb"
+    alb_internal                         = false
+    alb_load_balancer_type               = "application"
+    alb_enable_deletion_protection       = false # 생성하고 난 후에 true로 변경
+    alb_enable_cross_zone_load_balancing = true
+    alb_idle_timeout                     = 300
+    env                                  = "stg"
+  }
+}
+
+# ALB 보안그룹 생성
+alb_security_group = "terraform-ecs-alb-sg"
+
+# ALB Listencer 생성
+alb_listener = {
+  "terraform-ecs-alb-http-listener" = {
+    name              = "terraform-ecs-alb-http-listener"
+    port              = 80
+    protocol          = "HTTP"
+    load_balancer_arn = "terraform-ecs-alb" # 연결할 ALB 이름 지정
+    default_action = {
+      type             = "forward" # forward, redirect(다른 URL 전환), fixed-response(고정 응답값)
+      target_group_arn = "terraform-ecs-search-tg"
+    }
+    env = "stg"
+  },
+}
+
+# ALB Listener Rule 생성
+alb_listener_rule = {
+  "terraform-ecs-alb-http-listener-search-rule" = {
+    type              = "forward"
+    path              = ["/api/v1/*", "/search/*"]
+    alb_listener_name = "terraform-ecs-alb-http-listener"
+    target_group_name = "terraform-ecs-search-tg"
+    priority          = 1
+  },
+}
+
+# ALB Target Group 생성
+target_group = {
+  "terraform-ecs-search-tg" = {
+    target_group_name        = "terraform-ecs-search-tg"
+    target_group_port        = 8080
+    target_group_elb_type    = "ALB"
+    target_group_target_type = "ip" # FARGATE는 IP로 지정해야 함, 동적으로 IP(ENI) 할당됨
+    env                      = "stg"
+    health_check = {
+      enabled             = true
+      healthy_threshold   = 3
+      interval            = 30
+      port                = 8080
+      protocol            = "HTTP"
+      timeout             = 15
+      unhealthy_threshold = 5
+      internal            = false
+    }
+    enabled = true # health_check 바깥에 위치해야 함
+  },
+}
+
+####################
+# ECR 설정
+####################
+# ECR 리포지토리 생성
+ecr_repository = {
+  "core-search-api-server" : {
+    ecr_repository_name      = "core-search-api-server" # 리포지토리명
+    env                      = "stg"                    # ECR 개발환경
+    ecr_image_tag_mutability = "IMMUTABLE"              # image 버전 고유하게 관리할지 여부
+    ecr_scan_on_push         = false                    # PUSH Scan 여부
+    ecr_force_delete         = false
+  },
+  "core-filebeat" = {
+    ecr_repository_name      = "core-filebeat" # 리포지토리명
+    env                      = "stg"           # ECR 개발환경
+    ecr_image_tag_mutability = "IMMUTABLE"     # image 버전 고유하게 관리할지 여부
+    ecr_scan_on_push         = false           # PUSH Scan 여부
+    ecr_force_delete         = false
+  },
+}
+
+####################
+# ECS 클러스터 설정
+####################
+# ECS 클러스터 생성
+ecs_cluster = {
+  "core-search-cluster" = {
+    cluster_name = "core-search-cluster"
+    env          = "stg"
+  },
+}
+
+# ECS Security Group 
+# -> ecs_service 변수에 n개를 넣는건 이미 보안그룹이 존재하는 경우만 그렇게 사용 가능
+ecs_security_group = "core-search-ecs-sg"
+
+# ECS IAM Role
+ecs_task_role             = "ecs_task_role"
+ecs_task_role_policy      = "custom_ecs_task_role_policy"
+ecs_task_exec_role        = "ecs_task_exec_role"
+ecs_task_exec_role_policy = "custom_ecs_task_exec_role_policy"
+
+# ECS Container Image 버전
+# ecs_container_image_version = ""
+
+# ECS Task Definitions 생성
+# TODO: containers.env 추가? + image_version 어떻게 받을지?
+ecs_task_definitions = {
+  "core-search-td" = {
+    name                                    = "core-search-td"
+    task_role                               = "ecs_task_role"
+    task_exec_role                          = "ecs_task_exec_role"
+    network_mode                            = "awsvpc"
+    launch_type                             = "FARGATE"
+    task_total_cpu                          = 1024 # ECS Task Total CPU
+    task_total_memory                       = 2048 # ECS Task Total Mem
+    runtime_platform_oprating_system_family = "LINUX"
+    runtime_platform_cpu_architecture       = "X86_64"
+    task_family                             = "core-search-td"
+    cpu                                     = 1024
+    memory                                  = 2048
+    env                                     = "stg"
+    ephemeral_storage                       = 21
+    containers = [
+      {
+        name      = "core-search-api-server"
+        image     = "8xxxxxxxxxxx.dkr.ecr.ap-northeast-2.amazonaws.com/core-search-api-server"
+        version   = "latest" # container image version은 ecs_container_image_version 변수 사용
+        cpu       = 512      # container cpu
+        memory    = 1024     # container mem
+        port      = 8080
+        essential = true
+        env_variables = {
+          "TZ"                     = "Asia/Seoul"
+          "SPRING_PROFILES_ACTIVE" = "stg"
+        }
+        mount_points = []
+        health_check = {
+          command  = "curl --fail http://127.0.0.1:8080/search/health || exit 1"
+          interval = 30
+          timeout  = 10
+          retries  = 3
+        },
+        env = "stg"
+      },
+      {
+        name          = "core-filebeat"
+        image         = "8xxxxxxxxxxx.dkr.ecr.ap-northeast-2.amazonaws.com/core-filebeat"
+        version       = "latest" # container image version은 ecs_container_image_version 변수 사용
+        cpu           = 256      # container cpu
+        memory        = 512      # container mem
+        port          = 0
+        essential     = true
+        env_variables = {}
+        mount_points  = []
+        health_check = {
+          command  = "ps aux | grep filebeat || exit 1"
+          interval = 30
+          timeout  = 10
+          retries  = 3
+        },
+        env = "stg"
+      }
+    ]
+  },
+}
+
+# ECS 서비스 생성
+ecs_service = {
+  "core-search-service" = {
+    launch_type                   = "FARGATE"
+    service_role                  = "AWSServiceRoleForECS"
+    deployment_controller         = "ECS"
+    cluster_name                  = "core-search-cluster"
+    service_name                  = "core-search-service",        # 서비스 이름
+    desired_count                 = 1,                            # Task 개수
+    container_name                = "core-search-api-server-stg", # 컨테이너 이름
+    container_port                = 8080,                         # 컨테이너 포트
+    task_definitions              = "core-search-td"              # 테스크 지정
+    env                           = "stg"
+    health_check_grace_period_sec = 120  # 헬스 체크 그레이스 기간
+    assign_public_ip              = true # 우선 public zone에 구성
+  },
+}
+
+################
+# S3 설정
+################
+s3_bucket = {
+  terraform_state = {
+    bucket_name = "terraform-s3-devops-sample-state" # terraform state S3 버킷명
+  },
+}
+
+################
+# 공통 태그 설정
+################
+tags = {
+  env       = "stg"              # 개발 환경명 입력
+  project   = "terraform-ecs"    # 프로젝트명 입력
+  teamTag   = "devops"           # 팀 태그 입력
+  managedBy = "terraform"        # 해당 리소스가 어떤 서비스에 의해 생성이 되는지?(AWS Console, IaC?)
+  createdBy = "devops@gmail.com" # 인프라 생성자 혹은 팀의 이메일 계정 입력
+}

--- a/modules/aws/compute/ecs/outputs.tf
+++ b/modules/aws/compute/ecs/outputs.tf
@@ -1,0 +1,7 @@
+# modules/aws/compute/ecs/outputs.tf
+output "container_definitions" {
+  description = "ECS 작업 정의의 컨테이너 정의 JSON"
+  value = {
+    for k, v in data.template_file.container_definitions : k => v.rendered
+  }
+}

--- a/modules/aws/compute/ecs/task_definitions.tpl
+++ b/modules/aws/compute/ecs/task_definitions.tpl
@@ -1,41 +1,35 @@
 [
-  %{ for container in containers }
+  %{ for container in jsondecode(containers) }
   {
-    "name": "${container.name}-${container.env}",
+    "name": "${container.name}",
     "image": "${container.image}:${ecs_container_image_version}",
     "cpu": ${container.cpu},
     "memory": ${container.memory},
     "essential": ${container.essential},
     "portMappings": [
+      %{ if container.port != 0 }
       {
         "containerPort": ${container.port},
         "hostPort": ${container.port},
         "protocol": "tcp"
       }
-    ]%{ if length(container.env_variables) > 0 },
-    "env": [
+      %{ endif }
+    ],
+    "environment": [
       %{ for env_key, env_value in container.env_variables }
-      { 
-        "name": "${env_key}", 
-        "value": "${env_value}" 
-      }%{ if env_key != keys(container.env_variables)[-1] },%{ endif }
-      %{ endfor }
-    ]%{ endif },
-    "mountPoints": [
-      %{ for mount in container.mount_points }
       {
-        "sourceVolume": "${mount.sourceVolume}",
-        "containerPath": "${mount.containerPath}",
-        "readOnly": ${mount.readOnly}
-      }%{ if mount != container.mount_points[-1] },%{ endif }
+        "name": "${env_key}",
+        "value": "${env_value}"
+      }%{ if env_key != keys(container.env_variables)[length(keys(container.env_variables)) - 1] },%{ endif }
       %{ endfor }
     ],
+    "mountPoints": ${jsonencode(container.mount_points)},
     "healthCheck": {
       "command": ["CMD-SHELL", "${container.health_check.command}"],
       "interval": ${container.health_check.interval},
       "timeout": ${container.health_check.timeout},
       "retries": ${container.health_check.retries}
     }
-  }%{ if container != containers[-1] },%{ endif }
+  }%{ if index(jsondecode(containers), container) < length(jsondecode(containers)) - 1 },%{ endif }
   %{ endfor }
 ]

--- a/modules/aws/network/main.tf
+++ b/modules/aws/network/main.tf
@@ -73,16 +73,15 @@ resource "aws_nat_gateway" "ngw" {
 
 # 퍼블릭 라우팅 테이블 생성 -> 2개의 zone(a, b)에 각각 생성
 resource "aws_route_table" "public_route_table" {
-  count = local.az_count
-
   vpc_id = aws_vpc.main.id
+
   route {
     cidr_block = "0.0.0.0/0"                 # VPC Public Subnet 내의 모든 요청(0.0.0.0/0)을 IGW로 라우팅
     gateway_id = aws_internet_gateway.igw.id # Internet Gateway 참조 설정
   }
 
   tags = merge(var.tags, {
-    Name = "${format("%s-rt-pub-%s-%02d", local.project_name, local.env, count.index + 1)}"
+    Name = "${local.project_name}-rt-pub-${local.env}"
   })
 }
 
@@ -91,7 +90,7 @@ resource "aws_route_table_association" "public_route_table_association" {
   count = local.az_count
 
   subnet_id      = aws_subnet.public_subnet[count.index].id
-  route_table_id = aws_route_table.public_route_table[count.index].id
+  route_table_id = aws_route_table.public_route_table.id
 
   depends_on = [
     aws_route_table.public_route_table
@@ -100,16 +99,15 @@ resource "aws_route_table_association" "public_route_table_association" {
 
 # 프라이빗 라우팅 테이블 생성 -> 2개의 zone(a, b)에 각각 생성
 resource "aws_route_table" "private_route_table" {
-  count = local.az_count
-
   vpc_id = aws_vpc.main.id
+
   route {
-    cidr_block = "0.0.0.0/0"            # VPC Private Subnet 대역의 모든 요청을 NAT로 라우팅
-    gateway_id = aws_nat_gateway.ngw.id # NAT Gateway 참조 설정
+    cidr_block     = "0.0.0.0/0"            # VPC Private Subnet 대역의 모든 요청을 NAT로 라우팅
+    nat_gateway_id = aws_nat_gateway.ngw.id # NAT Gateway 참조 설정
   }
 
   tags = merge(var.tags, {
-    Name = "${format("%s-rt-pri-%s-%02d", local.project_name, local.env, count.index + 1)}"
+    Name = "${local.project_name}-rt-pri-${local.env}"
   })
 }
 
@@ -118,7 +116,7 @@ resource "aws_route_table_association" "private_route_table_association" {
   count = local.az_count
 
   subnet_id      = aws_subnet.private_subnet[count.index].id
-  route_table_id = aws_route_table.private_route_table[count.index].id
+  route_table_id = aws_route_table.private_route_table.id
 
   depends_on = [
     aws_route_table.private_route_table

--- a/modules/aws/storage/main.tf
+++ b/modules/aws/storage/main.tf
@@ -16,8 +16,7 @@ resource "aws_s3_bucket_versioning" "terraform_state" {
 
   bucket = aws_s3_bucket.terraform_state[each.key].id
   versioning_configuration {
-    status     = "Enabled" # 버전 관리 설정 - true
-    mfa_delete = "Enabled" # 객체 삭제 또는 버전 관리 비활성화를 시동할경우 MFA 토큰 입력 필요
+    status = "Enabled" # 버전 관리 설정 - true
   }
 }
 


### PR DESCRIPTION
1. ecs task_definitions.tpl 파일 문법 수정
2. 라우트 테이블 생성 시 public/private N개 당 1개의 rt를 참조해야하는데, rt N개가 생성이 되어서 수정
3. .gitignore에서 terraform.tfvars 제외, 로컬에서는 terraform-dev.tfvars를 사용
4. S3 버킷 생성 후 해당 버킷의 버저닝 비활성 시 MFA 없이 가능하도록 수정